### PR TITLE
fix: use .get() for sort_map to prevent KeyError on unknown sort values (#32)

### DIFF
--- a/tasks/views.py
+++ b/tasks/views.py
@@ -16,7 +16,7 @@ def index(request):
         'alpha':  'title',
     }
     # BUG: direct lookup raises KeyError if ?sort= contains an unexpected value
-    order_field = sort_map[sort]
+    order_field = sort_map.get(sort, sort_map['newest'])
     tasks = Task.objects.order_by(order_field)
 
     # Show a "last added" hint in the header


### PR DESCRIPTION
## Fix Issue #32: KeyError: 'popular' on unrecognized sort parameter

**Problem:** When `?sort=` contains an unrecognized value, `sort_map[sort]` raises `KeyError`. The code comment at line 18 explicitly marks this as a BUG.

**Fix:** Use `sort_map.get(sort, sort_map['newest'])` to fall back to the default sort instead of crashing.

```python
# Before
order_field = sort_map[sort]  # raises KeyError on unknown sort value

# After
order_field = sort_map.get(sort, sort_map['newest'])  # falls back safely
```